### PR TITLE
Update process.php

### DIFF
--- a/process.php
+++ b/process.php
@@ -170,7 +170,7 @@
 				);
 			
 				// Get the id of that inserted row
-				$new_id = mysql_insert_id();
+				$new_id = $wpdb->insert_id;
 				
 				// Update the following value to include the id
 				$post_title = "Variation #" . $new_id . " of " . $post_to_edit->post_title; //slug: has format of "Variation #(inserted_id) of (parent_title)"


### PR DESCRIPTION
mysql_insert_id() was deprecated in PHP 5.5.0, and removed in PHP 7.0.0